### PR TITLE
Update for OpenAI SDK v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It uses a combination of autonomous LangChain Agents and OpenAI's recently intro
 2. Search the web with DuckDuckGo to find the appropriate email address for takedown requests for that domain registrar
 3. Draft a takedown request email to the hosting provider citing the reason for the takedown request
 
+The application now relies on the OpenAI Python SDK v1 and supports the latest chat models.
+
 Created by [Matt Adams](https://www.linkedin.com/in/matthewrwadams/).
 
 ![TakedownGPT App Screenshot](screenshot.jpg)
@@ -15,7 +17,7 @@ Created by [Matt Adams](https://www.linkedin.com/in/matthewrwadams/).
 [Click here to try the live app!](https://takedowngpt.streamlit.app)
 
 ## New Feature ✨
-The app now supports performing domain registrar lookups using either WHOIS or RDAP. You can select your preferred protocol from the "Advanced Options" menu.
+The app now supports performing domain registrar lookups using either WHOIS or RDAP. You can select your preferred protocol from the "Advanced Options" menu. It also uses the latest OpenAI Python SDK with support for the current `gpt-3.5-turbo` and `gpt-4o` models.
 
 ## Installation
 

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import tldextract
 import whois
 import whoisit
 from langchain.agents import AgentType, Tool, initialize_agent
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langchain.tools import BaseTool
 from langchain.tools.ddg_search import DuckDuckGoSearchRun
 from pydantic import BaseModel, Field
@@ -27,10 +27,14 @@ api_key = st.sidebar.text_input("Enter your OpenAI API key:", type="password", h
 
 # Add 'Model Selection' section to the sidebar
 model_options = [
-    "gpt-3.5-turbo-0613",
-    "gpt-4-0613"
+    "gpt-3.5-turbo",
+    "gpt-4o"
 ]
-selected_model = st.sidebar.selectbox("Select the OpenAI model you would like to use:", model_options, help="You must have been given access to the [GPT-4 API](https://openai.com/waitlist/gpt-4-api) by OpenAI in order to use it.")
+selected_model = st.sidebar.selectbox(
+    "Select the OpenAI model you would like to use:",
+    model_options,
+    help="Select from the latest OpenAI chat models"
+)
 
 # Add 'About' section to the sidebar
 st.sidebar.header("About 🌐")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 tldextract==3.4.1
 python-whois==0.8.0
-langchain==0.0.204
-openai==0.27.4
+langchain>=0.1.13
+langchain-openai>=0.1.3
+openai>=1.0.0
 pydantic
 duckduckgo-search
 whoisit


### PR DESCRIPTION
## Summary
- update app to use `langchain_openai` and new ChatGPT models
- require `openai` v1 and modern LangChain packages
- clarify README with new OpenAI SDK version

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*